### PR TITLE
Recursive

### DIFF
--- a/recursive.js
+++ b/recursive.js
@@ -1,0 +1,41 @@
+var minimist = require('minimist')
+//  var cliclopts = require('cliclopts')
+//  var xtend = require('xtend')
+var debug = require('debug')('subcommand')
+
+function match(config, options, args, cmd) {
+    debug('cmd', cmd)
+    debug('args',args)
+    debug('config',config)
+    var argv = minimist(args)
+    debug('parsed', argv)
+
+    // if !cmd -> initial -> fix
+
+    if (cmd && cmd == config.name) {
+        config.command(argv)
+        return true
+    } 
+
+    var nextCmd = argv._.shift()
+    var nextArgs = args.filter(function(arg) { return arg != nextCmd })
+    var nextConfig = config.commands.filter(function(_cmd) { return _cmd.name == nextCmd })
+
+    debug('nextCmd', nextCmd)
+    debug('nextArgs', nextArgs)
+    debug('nextConfig', nextConfig)
+
+    // if !nextConfig -> die
+    if (nextConfig.length == 0) {
+        return false
+    }
+
+    return match(nextConfig[0], options, nextArgs, nextCmd)
+
+}
+
+module.exports = function(config, options) {
+  options = options || {}
+  config  = Array.isArray(config) ? { commands: config } : config
+  return match.bind(undefined, config, options)
+}

--- a/recursive.js
+++ b/recursive.js
@@ -4,15 +4,14 @@ var minimist = require('minimist')
 var debug = require('debug')('subcommand')
 
 function match(config, options, args, cmd) {
-    debug('cmd', cmd)
-    debug('args',args)
-    debug('config',config)
     var argv = minimist(args)
-    debug('parsed', argv)
 
-    // if !cmd -> initial -> fix
+    var moreCmds = false
+    if (argv._.length > 0 && config.commands) {
+        moreCmds = config.commands.filter(function(_cmd) { return _cmd.name == argv._[0]}).length > 0
+    }
 
-    if (cmd && cmd == config.name) {
+    if (cmd && cmd == config.name && !moreCmds) {
         config.command(argv)
         return true
     } 
@@ -21,11 +20,6 @@ function match(config, options, args, cmd) {
     var nextArgs = args.filter(function(arg) { return arg != nextCmd })
     var nextConfig = config.commands.filter(function(_cmd) { return _cmd.name == nextCmd })
 
-    debug('nextCmd', nextCmd)
-    debug('nextArgs', nextArgs)
-    debug('nextConfig', nextConfig)
-
-    // if !nextConfig -> die
     if (nextConfig.length == 0) {
         return false
     }

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 var test = require('tape')
-var sub = require('./')
+var sub = require('./recursive')
 
 function testCommands (onMatch, onAll, onNone) {
   var config = {
@@ -39,19 +39,23 @@ function testCommands (onMatch, onAll, onNone) {
         ],
         command: function cat (args) {
           onMatch('cat', args)
-        }
-      },
-      {
-        name: 'cat foo',
-        command: function catFoo (args) {
-          onMatch('cat foo', args)
-        }
-      },
-      {
-        name: 'cat foo bar',
-        command: function catFooBar (args) {
-          onMatch('cat foo bar', args)
-        }
+        },
+        commands: [
+          {
+            name: 'foo',
+            command: function catFoo (args) {
+              onMatch('cat foo', args)
+            },
+            commands: [
+              {
+                name: 'bar',
+                command: function catFooBar (args) {
+                  onMatch('cat foo bar', args)
+                }
+              }
+            ]
+          },
+        ]
       }
     ]
   }


### PR DESCRIPTION
I had this idea that if I focused on a single struct I could make a very simple recursive implementation.

``` js
{
  name:"",
  usage:"",
  options:{},
  command: function() {},
  commands: []
}
```

One could have arbitrary depth (kinda silly, but still) and return usage information at current level + above. This would allow nice nested usage output if one wanted (I do :stuck_out_tongue_closed_eyes:)

It works, but missing lots of details (that will clutter it up). Currently passing 20 of your 27 tests. Most of the broken ones are related to these special **root** and **none** functions.

It will break some of your current use-cases, and since you guys are using this quite heavily already I guess a merge is not really an option. I might just spin off as a separate module, but would love your feedback either way.

Also, I had a hard time with your standard js code style, so _npm test_ is currently not working :see_no_evil: 
