### PR TITLE
add usage option with cliclops.usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,8 @@ var commands = [
         name: 'loud',
         boolean: true,
         default: false,
-        abbr: 'v'
+        abbr: 'v',
+        help: 'print out all output loudly'
       }
     ],
     command: function foo (args) {
@@ -72,6 +73,7 @@ instead of an array, you can also pass an object that looks like this as the fir
   defaults: // default options
   all: // function that gets called always, regardless of match or no match
   none: // function that gets called only when there is no matched subcommand
+  usage: // subcommand to use for printing usage
   commands: // the commands array from basic usage
 }
 ```
@@ -132,6 +134,23 @@ pass a function under the `none` key and it will get called when no subcommand i
 ```js
 var config = {
   none: function none (args) { /** will only be called when no subcommand is matched **/ },
+  commands: yourSubCommandsArray
+}
+```
+
+### usage
+
+pass a name and command under the `usage` key and it will get called when no subcommand is matched and the name matches
+
+```js
+var config = {
+  usage: {
+    name: 'help', // subcommand to use for printing usage
+    command: function (args, cliclops.usage()) {
+      // optional function to print usage. second argument is a string from cliclops.usage()
+      // will call cliclops.print() if no command is specified.
+    }
+  }
   commands: yourSubCommandsArray
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -144,13 +144,15 @@ pass an option and command under the `usage` key and it will get called when tha
 
 #### Basic usage
 
+This will print usage from cliclops whenever the `--help` or `-h` options are used:
+
 ```js
 var config = {
   usage: true
 }
 ```
 
-This will print usage from cliclops whenever the `--help` or `-h` options are used.
+This will use `--info` instead of `--help`. And it will print `"general usage info"` before printing `cliclops.usage()`:
 
 ```js
 var config = {
@@ -163,8 +165,6 @@ var config = {
   }
 }
 ```
-
-This will use `--info` instead of `--help`. And it will print `"general usage info"` before printing `cliclops.usage()`
 
 #### Advanced Usage
 

--- a/readme.md
+++ b/readme.md
@@ -140,17 +140,68 @@ var config = {
 
 ### usage
 
-pass a name and command under the `usage` key and it will get called when no subcommand is matched and the name matches
+pass an option and command under the `usage` key and it will get called when that option is usage for the main command or subcommands. The usage option is `--help` and `-h` by default
+
+#### Basic usage
+
+```js
+var config = {
+  usage: true
+}
+```
+
+This will print usage from cliclops whenever the `--help` or `-h` options are used.
 
 ```js
 var config = {
   usage: {
-    name: 'help', // subcommand to use for printing usage
-    command: function (args, cliclops.usage()) {
-      // optional function to print usage. second argument is a string from cliclops.usage()
-      // will call cliclops.print() if no command is specified.
+    help: 'general usage info',
+    option: {
+      name: 'info',
+      abbr: 'i'
     }
   }
-  commands: yourSubCommandsArray
+}
+```
+
+This will use `--info` instead of `--help`. And it will print `"general usage info"` before printing `cliclops.usage()`
+
+#### Advanced Usage
+
+You can also define custom usage functions for the root and subcommands. These are passed the help text and `cliclops.usage()`.
+
+```js
+var config = {
+  usage: {
+    help: 'general help message', // Message to print before cliclops.usage()
+    option: {
+      // minimist option to use for printing usage
+      name: 'help',
+      abbr: 'h'
+    },
+    command: function (args, help, usage) {
+      // optional function to print usage. 
+      console.log(help) // prints: "general help message"
+      console.log(usage) // prints: cliclops.usage() 
+    }
+  },
+  commands: [{
+    name: 'foo',
+    help: 'foo help message',
+    options: [
+      {
+        name: 'loud',
+        help: 'print out all output loudly'
+      }
+    ],
+    usage: function (args, help, usage) {
+      // called when `foo` is matched and --help option is used
+      console.log(help) // prints: "foo help message"
+      console.log(usage) // prints: cliclops.usage()
+    },
+    command: function foo (args) {
+      // called when `foo` is matched
+    }
+  }]
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -140,11 +140,11 @@ var config = {
 
 ### usage
 
-pass an option and command under the `usage` key and it will get called when that option is usage for the main command or subcommands. The usage option is `--help` and `-h` by default
+The `usage` option makes it easy to print [cliclops usage](https://github.com/finnp/cliclopts#clioptsusage) for the root command and subcommands.
 
 #### Basic usage
 
-This will print usage from cliclops whenever the `--help` or `-h` options are used:
+By default, usage is printed with the `--help` or `-h` option. Set usage to true to print `cliclops.usage()` with `--help`:
 
 ```js
 var config = {
@@ -152,7 +152,7 @@ var config = {
 }
 ```
 
-This will use `--info` instead of `--help`. And it will print `"general usage info"` before printing `cliclops.usage()`:
+Use `usage.help` to print information above `cliclops.usage()`. Change the name of the usage option by specifying `usage.option`:
 
 ```js
 var config = {
@@ -165,6 +165,8 @@ var config = {
   }
 }
 ```
+
+This will print the usage with `--info` or `-i` instead of `--help`. The option is used for the root and subcommands.
 
 #### Advanced Usage
 

--- a/test.js
+++ b/test.js
@@ -22,18 +22,25 @@ function testCommands (onMatch, onAll, onNone, onUsage) {
     all: onAll,
     none: onNone,
     usage: {
-      name: 'help',
+      help: 'this is the general help',
+      option: {
+        name: 'help',
+        abbr: 'h'
+      },
       command: onUsage
     },
     commands: [
       {
         name: 'cat',
+        help: 'cat meow',
+        usage: onUsage,
         options: [
           {
             name: 'live',
             boolean: true,
             default: true,
-            abbr: 'l'
+            abbr: 'l',
+            help: 'live option'
           },
           {
             name: 'format',
@@ -218,13 +225,27 @@ test('none handler', function (t) {
 })
 
 test('usage handler', function (t) {
-  t.plan(4)
-  function onUsage (args, usage) {
+  t.plan(5)
+  function onUsage (args, help, usage) {
     t.ok(true, 'called onUsage')
+    t.ok(help, 'has general help')
     t.ok(usage, 'has cliclops usage')
     t.ok(usage.indexOf('version option') > -1, 'has version help')
   }
   var args = sub(testCommands(null, null, null, onUsage))
-  var handled = args(['help'])
+  var handled = args(['--help'])
+  t.equal(handled, true, 'returned true')
+})
+
+test('subcommand usage handler', function (t) {
+  t.plan(5)
+  function onUsage (args, help, usage) {
+    t.ok(true, 'called onUsage')
+    t.ok(help, 'has general help')
+    t.ok(usage, 'has cliclops usage')
+    t.ok(usage.indexOf('live option') > -1, 'has live help')
+  }
+  var args = sub(testCommands(null, null, null, onUsage))
+  var handled = args(['cat', '--help'])
   t.equal(handled, true, 'returned true')
 })

--- a/test.js
+++ b/test.js
@@ -1,13 +1,14 @@
 var test = require('tape')
 var sub = require('./')
 
-function testCommands (onMatch, onAll, onNone) {
+function testCommands (onMatch, onAll, onNone, onUsage) {
   var config = {
     root: {
       options: [{
         name: 'version',
         boolean: true,
-        abbr: 'v'
+        abbr: 'v',
+        help: 'version option'
       }],
       command: function noCommand (args) {
         onMatch('noCommand', args)
@@ -20,6 +21,10 @@ function testCommands (onMatch, onAll, onNone) {
     }],
     all: onAll,
     none: onNone,
+    usage: {
+      name: 'help',
+      command: onUsage
+    },
     commands: [
       {
         name: 'cat',
@@ -210,4 +215,16 @@ test('none handler', function (t) {
   t.equal(handled, true, 'returned true')
   var handled2 = args(['buffalo', 'wings'])
   t.equal(handled2, false, 'returned true')
+})
+
+test('usage handler', function (t) {
+  t.plan(4)
+  function onUsage (args, usage) {
+    t.ok(true, 'called onUsage')
+    t.ok(usage, 'has cliclops usage')
+    t.ok(usage.indexOf('version option') > -1, 'has version help')
+  }
+  var args = sub(testCommands(null, null, null, onUsage))
+  var handled = args(['help'])
+  t.equal(handled, true, 'returned true')
 })


### PR DESCRIPTION
Adds a `usage` option:

```js
var config = {
commands: [subcommands],
usage: {
  name: 'help', // subcommand to print usage on
  command: function (args, usage) { } // function to call to print usage
}
```

The custom usage function can print anything. But this also passes the `usage` from `cliclops.usage()` making it easy to print the options with cliclops. 

If no `command` is specified under usage, it will print usage `cliclops.print()`.