### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function findCommand (args, commands) {
         commandLength = c.name.length
       }
     })
-  var returnData = { command: match, commandLength: commandLength }
+  var returnData = { command: match, commandLength }
   debug('match', match)
   if (match) return returnData
   else return false


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This syntax is supported by Node.js 4 and newer, it seems like this library supports Node.js 8 and newer ✅ 
